### PR TITLE
Introduced SystemPollingManager

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,14 +4,6 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-08-29T21:20:28.782820600Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=ENJO1CGLEF" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/studiobot.xml
+++ b/.idea/studiobot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="StudioBotProjectSettings">
+    <option name="shareContext" value="OptedIn" />
+  </component>
+</project>

--- a/app/src/main/java/com/example/wooauto/presentation/screens/settings/PrinterSettings/PrinterSettingsScreen.kt
+++ b/app/src/main/java/com/example/wooauto/presentation/screens/settings/PrinterSettings/PrinterSettingsScreen.kt
@@ -812,21 +812,34 @@ private fun PrinterConfigItem(
                 Column(
                     modifier = Modifier.weight(1f)
                 ) {
-                    Text(
-                        text = printerConfig.name,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
-                    )
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = printerConfig.name,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        StatusChip(isConnected = isConnected)
+                    }
                     Spacer(modifier = Modifier.height(4.dp))
                     PrinterInfo(printerConfig)
                 }
                 
                 // 连接按钮
+                val isConnecting = !isConnected && isPrinting
                 Button(
                     onClick = onConnect,
-                    enabled = !isPrinting
+                    enabled = !isPrinting && !isConnecting
                 ) {
-                    if (isPrinting) {
+                    if (isConnecting) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            strokeWidth = 2.dp
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(text = stringResource(id = R.string.connecting_printer))
+                    } else if (isPrinting) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(16.dp),
                             color = MaterialTheme.colorScheme.onPrimary,
@@ -967,6 +980,29 @@ private fun PrinterConfigItem(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun StatusChip(isConnected: Boolean) {
+    val bg = if (isConnected) MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)
+             else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
+    val fg = if (isConnected) MaterialTheme.colorScheme.primary
+             else MaterialTheme.colorScheme.onSurfaceVariant
+    val label = if (isConnected) stringResource(id = R.string.connected)
+                else stringResource(id = R.string.disconnect)
+
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(999.dp))
+            .background(bg)
+            .padding(horizontal = 8.dp, vertical = 2.dp)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = fg
+        )
     }
 }
 

--- a/app/src/main/java/com/example/wooauto/presentation/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/wooauto/presentation/screens/settings/SettingsScreen.kt
@@ -170,15 +170,24 @@ fun SettingsScreen(
                                 val currentPrinter = viewModel.currentPrinterConfig.collectAsState().value
                                 val printerStatus = viewModel.printerStatus.collectAsState().value
                                 val defaultLabel = stringResource(R.string.default_printer_label)
-                                
-                                if (currentPrinter != null && printerStatus.name == "CONNECTED") {
-                                    "${currentPrinter.name} - ${currentPrinter.paperWidth}mm"
-                                } else {
-                                    val defaultPrinter = viewModel.printerConfigs.collectAsState().value.find { it.isDefault }
-                                    if (defaultPrinter != null) {
-                                        "${defaultPrinter.name} - ${defaultPrinter.paperWidth}mm ($defaultLabel)"
-                                    } else {
-                                        stringResource(R.string.no_printers_configured_prompt)
+                                val connectedLabel = stringResource(R.string.connected)
+
+                                when {
+                                    currentPrinter != null -> {
+                                        val base = "${currentPrinter.name} - ${currentPrinter.paperWidth}mm"
+                                        if (printerStatus == com.example.wooauto.domain.printer.PrinterStatus.CONNECTED) {
+                                            "$base ($connectedLabel)"
+                                        } else {
+                                            base
+                                        }
+                                    }
+                                    else -> {
+                                        val defaultPrinter = viewModel.printerConfigs.collectAsState().value.find { it.isDefault }
+                                        if (defaultPrinter != null) {
+                                            "${defaultPrinter.name} - ${defaultPrinter.paperWidth}mm ($defaultLabel)"
+                                        } else {
+                                            stringResource(R.string.no_printers_configured_prompt)
+                                        }
                                     }
                                 }
                             },

--- a/app/src/main/java/com/example/wooauto/service/SystemPollingManager.kt
+++ b/app/src/main/java/com/example/wooauto/service/SystemPollingManager.kt
@@ -1,0 +1,119 @@
+package com.example.wooauto.service
+
+import android.content.Context
+import android.util.Log
+import com.example.wooauto.BuildConfig
+import com.example.wooauto.domain.models.PrinterConfig
+import com.example.wooauto.domain.printer.PrinterManager
+import com.example.wooauto.domain.printer.PrinterStatus
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 系统轮询管理器
+ * - 统一承载所有“非订单类”的周期性检查（网络心跳、看门狗、打印机健康检查）
+ * - 内部不直接修改业务状态，只通过 PrinterManager 等领域组件进行状态更新
+ */
+@Singleton
+class SystemPollingManager @Inject constructor(
+	@ApplicationContext private val context: Context,
+	private val printerManager: PrinterManager,
+) {
+	companion object {
+		private const val TAG = "SystemPollingManager"
+		private const val NETWORK_HEARTBEAT_INTERVAL_MS = 30_000L
+		private const val WATCHDOG_INTERVAL_MS = 30_000L
+		private const val PRINTER_HEALTH_INTERVAL_MS = 5_000L
+	}
+
+	private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+	private var networkHeartbeatJob: Job? = null
+	private var watchdogJob: Job? = null
+	private var printerHealthJob: Job? = null
+
+	fun startAll(defaultPrinterProvider: suspend () -> PrinterConfig?) {
+		startNetworkHeartbeat()
+		startWatchdog()
+		startPrinterHealth(defaultPrinterProvider)
+	}
+
+	fun stopAll() {
+		networkHeartbeatJob?.cancel(); networkHeartbeatJob = null
+		watchdogJob?.cancel(); watchdogJob = null
+		printerHealthJob?.cancel(); printerHealthJob = null
+	}
+
+	private fun startNetworkHeartbeat() {
+		if (networkHeartbeatJob?.isActive == true) return
+		if (BuildConfig.DEBUG) Log.d(TAG, "系统轮询/网络：启动网络心跳")
+		networkHeartbeatJob = scope.launch {
+			while (isActive) {
+				try {
+					if (BuildConfig.DEBUG) Log.d(TAG, "系统轮询/网络：执行网络心跳")
+					// 此处保留空实现：原网络心跳逻辑仍在 BackgroundPollingService 中
+					// 迁移时由服务改为委托本管理器或直接在此实现
+				} catch (e: Exception) {
+					Log.e(TAG, "系统轮询/网络：心跳异常: ${e.message}", e)
+				} finally {
+					delay(NETWORK_HEARTBEAT_INTERVAL_MS)
+				}
+			}
+		}
+	}
+
+	private fun startWatchdog() {
+		if (watchdogJob?.isActive == true) return
+		if (BuildConfig.DEBUG) Log.d(TAG, "系统轮询/看门狗：启动")
+		watchdogJob = scope.launch {
+			while (isActive) {
+				try {
+					if (BuildConfig.DEBUG) Log.d(TAG, "系统轮询/看门狗：检查轮询健康")
+					// 此处保留空实现：原看门狗逻辑仍在 BackgroundPollingService 中
+				} catch (e: Exception) {
+					Log.e(TAG, "系统轮询/看门狗：异常: ${e.message}", e)
+				} finally {
+					delay(WATCHDOG_INTERVAL_MS)
+				}
+			}
+		}
+	}
+
+	private fun startPrinterHealth(defaultPrinterProvider: suspend () -> PrinterConfig?) {
+		if (printerHealthJob?.isActive == true) return
+		Log.d(TAG, "系统轮询/打印机：启动")
+		printerHealthJob = scope.launch {
+			while (isActive) {
+				try {
+					val config = try { defaultPrinterProvider() } catch (_: Exception) { null }
+					if (config != null) {
+						// 仅触发检查与恢复，具体状态更新在 PrinterManager 内部完成
+						try {
+							val status = printerManager.getPrinterStatus(config)
+							if (status != PrinterStatus.CONNECTED) {
+								printerManager.connect(config)
+							} else {
+								// 轻量测试，失败时由 manager 标记并自行重连
+								printerManager.testConnection(config)
+							}
+						} catch (e: Exception) {
+							Log.e(TAG, "系统轮询/打印机：检查异常: ${e.message}", e)
+						}
+					}
+				} catch (e: Exception) {
+					Log.e(TAG, "系统轮询/打印机：循环异常: ${e.message}", e)
+				} finally {
+					delay(PRINTER_HEALTH_INTERVAL_MS)
+				}
+			}
+		}
+	}
+}

--- a/app/src/main/java/com/example/wooauto/service/SystemPollingManager.kt
+++ b/app/src/main/java/com/example/wooauto/service/SystemPollingManager.kt
@@ -18,9 +18,9 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * 系统轮询管理器
- * - 统一承载所有“非订单类”的周期性检查（网络心跳、看门狗、打印机健康检查）
- * - 内部不直接修改业务状态，只通过 PrinterManager 等领域组件进行状态更新
+ * System Polling Manager
+ * - Centralizes all non-order-related periodic checks (network heartbeat, watchdog, printer health checks)
+ * - Does not directly modify business state; updates status only via domain components such as PrinterManager
  */
 @Singleton
 class SystemPollingManager @Inject constructor(


### PR DESCRIPTION
Created a unified “System Polling” manager to handle non-order polling: network heartbeat, watchdog, and printer health checks. Wired it into BackgroundPollingService (start/stop on service lifecycle). Standardized logs: “System Polling/Network…”, “System Polling/Watchdog…”, “System Polling/Printer…”. Decoupled printer health loop from BluetoothPrinterManager Added externalPollingEnabled flag to let SystemPollingManager own printer health checks. When enabled, internal heartbeat loop is disabled to avoid duplicate loops. Kept manager as the single source of truth for PrinterStatus (no UI writes). Hardened printer disconnection detection
Added ACTION_ACL_DISCONNECT_REQUESTED to the BT broadcast receiver and a fallback path when device info is absent. Switched heartbeat probe from NUL byte to ESC @ and added a post-write socket re-check. Fixed race/ordering by starting heartbeat after CONNECTED state is set and guarding stop/start. Added a dedicated dispatcher for the internal loop (then replaced by external polling when enabled). UI state and subscriptions
SettingsViewModel now flatMapLatest-subscribe to printerManager.getPrinterStatusFlow(currentPrinter), ensuring UI reflects real-time status changes (incl. disconnect). Added a “Connecting” UI state with a 30s timeout fallback to “Disconnected” (UI-only; background continues trying). In PrinterSettingsScreen, the connect button shows a progress indicator and is disabled while connecting to prevent duplicate actions. Safer behavior and clarity
Renamed logs for clarity (System Polling vs. Order Polling). Prevented accidental heartbeat cancellations and ensured heartbeat re-start if ever inactive. Deprication candidates (safe removals after stabilization) BackgroundPollingService’s internal network heartbeat and watchdog can be fully delegated to SystemPollingManager and then removed. BluetoothPrinterManager’s internal while-loop heartbeat can be retired once external polling proves stable (keep health-check methods and event-driven updates).